### PR TITLE
feat: Add cors support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-decouple==3.8
 python_jose==3.3.0
 psycopg2==2.9.9
 cryptography==42.0.8
+django-cors-headers==4.5.0

--- a/todo_list_custom_backend/settings.py
+++ b/todo_list_custom_backend/settings.py
@@ -32,10 +32,12 @@ ALLOWED_HOSTS = [
     '*'
 ]
 
+CORS_ALLOW_ALL_ORIGINS = True
 
 # Application definition
 
 INSTALLED_APPS = [
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -47,6 +49,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
# Overview

Web support has been added to the Flutter Django demo in https://github.com/powersync-ja/powersync.dart/pull/200. Using this backend in a browser requires the HTTP routes to allow cross-origin requests. This PR adds CORS headers to allow requests from any domain.

See the snapshot of the Chrome Network tools while running the Flutter Django demo in web. The response headers now contain CORS values.
![image](https://github.com/user-attachments/assets/a7c8c346-2428-4aaf-bee6-901e3f231ded)
